### PR TITLE
HotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfix

### DIFF
--- a/music-generate-api/app/main.py
+++ b/music-generate-api/app/main.py
@@ -70,7 +70,7 @@ async def lifespan(app: FastAPI):
     print("[App] Shutting down...!")
 
 app = FastAPI(
-    title="Катюша, уроки музыки", description="Сервис \"Катюши\" по генерации музыки", version="1.2.0",
+    title="Катюша, уроки музыки", description="Сервис \"Катюши\" по генерации музыки", version="1.1.1",
     summary="Adeptus Altusches Team",
     lifespan=lifespan
 )

--- a/music-generate-api/app/services/ai_service.py
+++ b/music-generate-api/app/services/ai_service.py
@@ -27,12 +27,12 @@ class AiService:
 
         print("[AI] Ready!")
 
-    def generate(self, *prompt: str, output_path: str="/out/result.mp3", context_size: int = 1024):
+    def generate(self, prompt: str, output_path: str="out/result.mp3", context_size: int = 1024):
         self.is_busy = True
 
         print("[AI] Setup Generation...")
         inputs = self.__processor(
-            text=list(prompt),
+            text=[prompt],
             padding=True,
             return_tensors="pt",
         )


### PR DESCRIPTION
HotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfixHotfix
